### PR TITLE
Feature/profile img upload

### DIFF
--- a/src/api/mutator/custom-instance.ts
+++ b/src/api/mutator/custom-instance.ts
@@ -125,14 +125,16 @@ const refreshTokens = async () => {
 };
 
 export const customInstance = async <TResponse>(url: string, config: CustomInstanceConfig = {}): Promise<TResponse> => {
-    const { params, headers, ...requestInit } = config;
+    const { params, headers, body, ...requestInit } = config;
+    const isFormDataBody = typeof FormData !== 'undefined' && body instanceof FormData;
 
     // INFO: 생성된 모든 API 호출은 이 함수로 들어오며, base URL과 인증 헤더를 공통 적용합니다.
     const executeRequest = async (accessToken?: string) =>
         fetch(buildRequestUrl(url, params), {
             ...requestInit,
+            body,
             headers: {
-                'Content-Type': 'application/json',
+                ...(isFormDataBody ? {} : { 'Content-Type': 'application/json' }),
                 ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
                 ...headers,
             },

--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -1,3 +1,4 @@
+import type { User } from '@/api/generated/model/user';
 import type { Login200 } from '@/api/generated/model/login200';
 import type { AuthTokens, AuthUser } from './types';
 
@@ -6,6 +7,13 @@ export const mapLoginResponseToAuthUser = (response: Login200): AuthUser => ({
     loginId: response.user?.login_id ?? '',
     nickname: response.user?.nickname ?? '',
     avatarSrc: response.user?.avatar_url ?? null,
+});
+
+export const mapUserResponseToAuthUser = (response: User): AuthUser => ({
+    id: response.id ?? '',
+    loginId: response.login_id ?? '',
+    nickname: response.nickname ?? '',
+    avatarSrc: response.avatar_url ?? null,
 });
 
 export const mapLoginResponseToAuthTokens = (response: Login200): AuthTokens => ({

--- a/src/features/auth/avatarStorage.ts
+++ b/src/features/auth/avatarStorage.ts
@@ -1,0 +1,16 @@
+import type { User } from '@/api/generated/model/user';
+import { customInstance } from '@/api/mutator/custom-instance';
+
+const avatarApiBasePath = '/api/v1/users/me/avatar';
+
+export const uploadUserAvatar = async (file: File) => {
+    const formData = new FormData();
+    formData.append('avatar', file);
+
+    return customInstance<User>(avatarApiBasePath, {
+        method: 'POST',
+        body: formData,
+    });
+};
+
+export const deleteUserAvatar = async () => customInstance<User>(avatarApiBasePath, { method: 'DELETE' });

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,4 +1,6 @@
 export * from './types';
+export * from './avatarStorage';
+export * from './api';
 export * from './useAuthStore';
 export * from './useLoginForm';
 export * from './useSignupForm';

--- a/src/features/auth/useAuthStore.ts
+++ b/src/features/auth/useAuthStore.ts
@@ -8,6 +8,7 @@ interface AuthStoreState {
     user: AuthUser | null;
     tokens: AuthTokens | null;
     login: (user: AuthUser, tokens?: AuthTokens | null) => void;
+    updateUser: (updates: Partial<AuthUser>) => void;
     setTokens: (tokens: AuthTokens | null) => void;
     logout: () => void;
 }
@@ -25,6 +26,12 @@ export const useAuthStore = create<AuthStoreState>()(
                     user,
                     tokens,
                 });
+            },
+            updateUser: (updates) => {
+                set((state) => ({
+                    ...state,
+                    user: state.user ? { ...state.user, ...updates } : state.user,
+                }));
             },
             setTokens: (tokens) => {
                 // INFO: refresh 성공 후에는 사용자 정보는 유지하고 토큰만 교체합니다.

--- a/src/features/settings/bgmStorage.ts
+++ b/src/features/settings/bgmStorage.ts
@@ -1,5 +1,3 @@
-import { bgmTracks } from './tracks';
-
 export interface BgmPersistedState {
     playerVolume: number;
     playerPlaying: boolean;
@@ -12,14 +10,11 @@ export const defaultBgmVolume = 40;
 
 // INFO: 새로고침 후 마지막 트랙/볼륨/재생 위치를 복원하기 위한 초기값 로더입니다.
 export const getPersistedBgmState = (): BgmPersistedState => {
-    // INFO: 저장된 값이 없을 때는 첫 트랙과 기본 볼륨으로 안전하게 시작합니다.
-    const fallbackTrackId = bgmTracks[0]?.id ?? null;
-
     if (typeof window === 'undefined') {
         return {
             playerVolume: defaultBgmVolume,
             playerPlaying: false,
-            currentTrackId: fallbackTrackId,
+            currentTrackId: null,
             currentTime: 0,
         };
     }
@@ -31,7 +26,7 @@ export const getPersistedBgmState = (): BgmPersistedState => {
             return {
                 playerVolume: defaultBgmVolume,
                 playerPlaying: false,
-                currentTrackId: fallbackTrackId,
+                currentTrackId: null,
                 currentTime: 0,
             };
         }
@@ -42,14 +37,14 @@ export const getPersistedBgmState = (): BgmPersistedState => {
         return {
             playerVolume: typeof state.playerVolume === 'number' ? state.playerVolume : defaultBgmVolume,
             playerPlaying: Boolean(state.playerPlaying),
-            currentTrackId: typeof state.currentTrackId === 'string' ? state.currentTrackId : fallbackTrackId,
+            currentTrackId: typeof state.currentTrackId === 'string' ? state.currentTrackId : null,
             currentTime: typeof state.currentTime === 'number' ? state.currentTime : 0,
         };
     } catch {
         return {
             playerVolume: defaultBgmVolume,
             playerPlaying: false,
-            currentTrackId: fallbackTrackId,
+            currentTrackId: null,
             currentTime: 0,
         };
     }

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,3 +1,2 @@
-export { bgmPlayerItems, bgmTracks } from './tracks';
 export { useBgmPlayer } from './useBgmPlayer';
 export type { BgmPlayerItem } from './tracks';

--- a/src/features/settings/tracks.ts
+++ b/src/features/settings/tracks.ts
@@ -1,6 +1,6 @@
-import { getSupabaseAudioUrl } from '@/lib/storage';
+import { getSupabaseAudioUrl, listSupabaseAudioFiles, listSupabaseAudioFolders } from '@/lib/storage';
 
-type BgmCategory = 'lofi' | 'rain' | 'cafe';
+type BgmCategory = 'lofi' | 'rain' | 'cafe' | (string & {});
 
 export interface BgmTrack {
     id: string;
@@ -18,7 +18,7 @@ export interface BgmPlayerItem {
     imageSrc: string;
 }
 
-const categoryMeta: Record<BgmCategory, Omit<BgmPlayerItem, 'id'>> = {
+const categoryMeta: Partial<Record<BgmCategory, Omit<BgmPlayerItem, 'id'>>> = {
     lofi: {
         title: 'Lo-fi',
         description: '아날로그 감성',
@@ -36,25 +36,65 @@ const categoryMeta: Record<BgmCategory, Omit<BgmPlayerItem, 'id'>> = {
     },
 };
 
-const trackDefinitions = [
-    { category: 'cafe', fileName: 'cafe_01' },
-    { category: 'cafe', fileName: 'cafe_02' },
-    { category: 'lofi', fileName: 'lofi_01' },
-    { category: 'lofi', fileName: 'lofi_02' },
-    { category: 'rain', fileName: 'rain_01' },
-    { category: 'rain', fileName: 'rain_02' },
-] as const satisfies ReadonlyArray<{ category: BgmCategory; fileName: string }>;
+const defaultCategoryImage = '/img_player_01.png';
 
-export const bgmPlayerItems: BgmPlayerItem[] = (Object.keys(categoryMeta) as BgmCategory[]).map((category) => ({
-    id: category,
-    ...categoryMeta[category],
-}));
+const toTitleCase = (value: string) => {
+    return value
+        .split(/[-_\s]+/)
+        .filter(Boolean)
+        .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+        .join(' ');
+};
 
-export const bgmTracks: BgmTrack[] = trackDefinitions.map(({ category, fileName }) => ({
-    id: `${category}/${fileName}`,
-    category,
-    title: categoryMeta[category].title,
-    description: categoryMeta[category].description,
-    imageSrc: categoryMeta[category].imageSrc,
-    src: getSupabaseAudioUrl(`bgm/${category}/${fileName}.mp3`),
-}));
+const getCategoryMetadata = (category: string): Omit<BgmPlayerItem, 'id'> => {
+    return (
+        categoryMeta[category] ?? {
+            title: toTitleCase(category),
+            description: `${category} 사운드`,
+            imageSrc: defaultCategoryImage,
+        }
+    );
+};
+
+let bgmTracksPromise: Promise<BgmTrack[]> | null = null;
+
+export const loadBgmTracks = async () => {
+    if (!bgmTracksPromise) {
+        bgmTracksPromise = (async () => {
+            const categoryEntries = await listSupabaseAudioFolders('bgm');
+
+            const trackGroups = await Promise.all(
+                categoryEntries.map(async ({ name }) => {
+                    const files = await listSupabaseAudioFiles(`bgm/${name}`);
+                    const metadata = getCategoryMetadata(name);
+
+                    return files.map(({ name: fileName }) => {
+                        const trackName = fileName.replace(/\.[^.]+$/, '');
+
+                        return {
+                            id: `${name}/${trackName}`,
+                            category: name,
+                            title: metadata.title,
+                            description: metadata.description,
+                            imageSrc: metadata.imageSrc,
+                            src: getSupabaseAudioUrl(`bgm/${name}/${fileName}`),
+                        } satisfies BgmTrack;
+                    });
+                })
+            );
+
+            return trackGroups.flat();
+        })();
+    }
+
+    return bgmTracksPromise;
+};
+
+export const buildBgmPlayerItems = (tracks: BgmTrack[]): BgmPlayerItem[] => {
+    const categorySet = new Set(tracks.map((track) => track.category));
+
+    return Array.from(categorySet).map((category) => ({
+        id: category,
+        ...getCategoryMetadata(category),
+    }));
+};

--- a/src/features/settings/useBgmPlayer.ts
+++ b/src/features/settings/useBgmPlayer.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
@@ -12,7 +13,7 @@ import {
     syncAudioTrack,
 } from './bgmAudioRuntime';
 import { bgmStorageKey, getPersistedBgmState } from './bgmStorage';
-import { bgmPlayerItems, bgmTracks } from './tracks';
+import { buildBgmPlayerItems, loadBgmTracks, type BgmTrack } from './tracks';
 
 // INFO: store와 audio 싱글턴이 같은 초기값에서 시작하도록 persisted 상태를 먼저 읽습니다.
 const persistedInitialState = getPersistedBgmState();
@@ -20,8 +21,6 @@ const persistedInitialState = getPersistedBgmState();
 if (bgmAudio) {
     bgmAudio.preload = 'auto';
     bgmAudio.volume = persistedInitialState.playerVolume / 100;
-    syncAudioTrack(bgmTracks, persistedInitialState.currentTrackId);
-    syncAudioCurrentTime(persistedInitialState.currentTime);
 }
 
 interface BgmPlayerStoreState {
@@ -72,60 +71,100 @@ const useBgmPlayerStore = create<BgmPlayerStoreState>()(
     )
 );
 
-if (bgmAudio) {
-    // INFO: audio 엘리먼트 이벤트를 store와 동기화해서 화면 전환 후에도 상태를 이어갑니다.
-    const audio = bgmAudio;
-    const initialState = useBgmPlayerStore.getState();
-    audio.volume = initialState.playerVolume / 100;
-
-    audio.addEventListener('ended', () => {
-        const nextTrackId = moveTrackId(bgmTracks, useBgmPlayerStore.getState().currentTrackId, 1);
-
-        if (!nextTrackId) {
-            useBgmPlayerStore.getState().setPlayerPlaying(false);
-            return;
-        }
-
-        useBgmPlayerStore.getState().setCurrentTrackId(nextTrackId);
-        useBgmPlayerStore.getState().setCurrentTime(0);
-
-        if (useBgmPlayerStore.getState().playerPlaying) {
-            playCurrentTrack(bgmTracks, nextTrackId, () => useBgmPlayerStore.getState().setPlayerPlaying(false));
-        }
-    });
-
-    audio.addEventListener('timeupdate', () => {
-        useBgmPlayerStore.getState().setCurrentTime(audio.currentTime);
-    });
-
-    if (initialState.playerPlaying && audio.paused) {
-        playCurrentTrack(bgmTracks, initialState.currentTrackId, () => {
-            armResumeOnInteraction(bgmTracks, useBgmPlayerStore.getState);
-        });
-    }
-}
-
 export const useBgmPlayer = () => {
+    const [bgmTracks, setBgmTracks] = useState<BgmTrack[]>([]);
     // INFO: 이 훅은 UI가 바로 사용할 핸들러와 현재 재생 상태만 노출합니다.
     const playerVolume = useBgmPlayerStore((state) => state.playerVolume);
     const playerPlaying = useBgmPlayerStore((state) => state.playerPlaying);
     const currentTrackId = useBgmPlayerStore((state) => state.currentTrackId);
-    // const currentTime = useBgmPlayerStore((state) => state.currentTime);
+    const currentTime = useBgmPlayerStore((state) => state.currentTime);
     const setPlayerVolume = useBgmPlayerStore((state) => state.setPlayerVolume);
     const setPlayerPlaying = useBgmPlayerStore((state) => state.setPlayerPlaying);
     const setCurrentTrackId = useBgmPlayerStore((state) => state.setCurrentTrackId);
     const setCurrentTime = useBgmPlayerStore((state) => state.setCurrentTime);
 
+    useEffect(() => {
+        let cancelled = false;
+
+        const loadTracks = async () => {
+            try {
+                const tracks = await loadBgmTracks();
+
+                if (!cancelled) {
+                    setBgmTracks(tracks);
+                }
+            } catch (error) {
+                console.error('BGM 목록을 불러오지 못했습니다.', error);
+            }
+        };
+
+        void loadTracks();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!bgmAudio || bgmTracks.length === 0) {
+            return;
+        }
+
+        const resolvedTrackId = getTrackById(bgmTracks, currentTrackId)?.id ?? bgmTracks[0]?.id ?? null;
+
+        if (resolvedTrackId !== currentTrackId) {
+            setCurrentTrackId(resolvedTrackId);
+            setCurrentTime(0);
+            return;
+        }
+
+        syncAudioTrack(bgmTracks, resolvedTrackId);
+        syncAudioCurrentTime(currentTime);
+
+        if (playerPlaying && bgmAudio.paused) {
+            playCurrentTrack(bgmTracks, resolvedTrackId, () => {
+                armResumeOnInteraction(bgmTracks, useBgmPlayerStore.getState);
+            });
+        }
+    }, [bgmTracks, currentTime, currentTrackId, playerPlaying, setCurrentTime, setCurrentTrackId]);
+
+    useEffect(() => {
+        if (!bgmAudio || bgmTracks.length === 0) {
+            return;
+        }
+
+        const audio = bgmAudio;
+
+        const handleEnded = () => {
+            const nextTrackId = moveTrackId(bgmTracks, useBgmPlayerStore.getState().currentTrackId, 1);
+
+            if (!nextTrackId) {
+                useBgmPlayerStore.getState().setPlayerPlaying(false);
+                return;
+            }
+
+            useBgmPlayerStore.getState().setCurrentTrackId(nextTrackId);
+            useBgmPlayerStore.getState().setCurrentTime(0);
+
+            if (useBgmPlayerStore.getState().playerPlaying) {
+                playCurrentTrack(bgmTracks, nextTrackId, () => useBgmPlayerStore.getState().setPlayerPlaying(false));
+            }
+        };
+
+        const handleTimeUpdate = () => {
+            useBgmPlayerStore.getState().setCurrentTime(audio.currentTime);
+        };
+
+        audio.addEventListener('ended', handleEnded);
+        audio.addEventListener('timeupdate', handleTimeUpdate);
+
+        return () => {
+            audio.removeEventListener('ended', handleEnded);
+            audio.removeEventListener('timeupdate', handleTimeUpdate);
+        };
+    }, [bgmTracks]);
+
     const currentTrack = getTrackById(bgmTracks, currentTrackId);
-
-    // INFO: 훅 렌더마다 시간을 다시 밀어넣으면 재생 중 위치가 튈 수 있어서 트랙만 동기화합니다.
-    syncAudioTrack(bgmTracks, currentTrackId);
-
-    if (bgmAudio && currentTrack && playerPlaying && bgmAudio.paused) {
-        playCurrentTrack(bgmTracks, currentTrack.id, () => {
-            armResumeOnInteraction(bgmTracks, useBgmPlayerStore.getState);
-        });
-    }
 
     // INFO: input range는 값만 바꾸고 실제 volume 반영은 store setter에서 처리합니다.
     const handlePlayerVolumeChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -194,7 +233,7 @@ export const useBgmPlayer = () => {
         });
     };
 
-    const playerItems = bgmPlayerItems.map((item) => ({
+    const playerItems = buildBgmPlayerItems(bgmTracks).map((item) => ({
         ...item,
         active: currentTrack?.category === item.id,
     }));
@@ -209,5 +248,6 @@ export const useBgmPlayer = () => {
         onPlayerPrevious: handlePlayerPrevious,
         onPlayerNext: handlePlayerNext,
         onPlayerItemSelect: handlePlayerItemSelect,
+        tracksReady: bgmTracks.length > 0,
     };
 };

--- a/src/features/timer/components/FocusMode.tsx
+++ b/src/features/timer/components/FocusMode.tsx
@@ -9,7 +9,7 @@ import { Button } from '@@/ui/Button';
 import { Icon } from '@@/ui/Icon/Icon';
 import { PlayerButton } from '@@/ui/PlayerButton';
 import { TodoPanel } from '@@@/todo';
-import { focusModeBackgrounds, useFocusModeBackground, FocusModeBackgroundLayer, SessionIndicator } from '@@@/timer';
+import { useFocusModeBackground, FocusModeBackgroundLayer, SessionIndicator } from '@@@/timer';
 
 const backgroundNavButtonWrapperClassName = 'bottom-0 group absolute inset-y-40 z-30 w-28 hover:cursor-pointer';
 
@@ -47,9 +47,10 @@ export const FocusMode = ({
     const wasOpenRef = useRef(false);
     const [isTodoExpanded, setIsTodoExpanded] = useState(false);
     const { showToast } = useToast();
-    const { backgroundSlideClassNames, handleNextBackground, handlePrevBackground } = useFocusModeBackground({
-        backgroundIndex,
-    });
+    const { focusModeBackgrounds, backgroundSlideClassNames, handleNextBackground, handlePrevBackground } =
+        useFocusModeBackground({
+            backgroundIndex,
+        });
 
     const isRunning = useTimerStore((state) => state.isRunning);
     const remainingSeconds = useTimerStore((state) => state.remainingSeconds);

--- a/src/features/timer/index.ts
+++ b/src/features/timer/index.ts
@@ -7,7 +7,7 @@ export { FocusModeBackgroundLayer } from './components/FocusModeBackgroundLayer'
 export { TimerTicker } from './components/TimerTicker';
 export { getInitialSeconds } from './selectors';
 
-export { useFocusModeBackground, focusModeBackgrounds } from './useFocusModeBackground';
+export { useFocusModeBackground } from './useFocusModeBackground';
 export { useTimerMetadata } from './useTimerMetadata';
 export { useTimerNotifications } from './useTimerNotifications';
 export { useTimerSession } from './useTimerSessionView';

--- a/src/features/timer/useFocusModeBackground.ts
+++ b/src/features/timer/useFocusModeBackground.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { getSupabaseImageUrl } from '@/lib/storage';
+import { getSupabaseImageUrl, listSupabaseImageFiles } from '@/lib/storage';
 
 import { useFocusModeBackgroundStore } from './useFocusModeStore';
 
@@ -13,20 +13,17 @@ interface BackgroundTransitionState {
     phase: 'prepare' | 'animate';
 }
 
-const backgroundFileNames = [
-    'focusModeBG_01.png',
-    'focusModeBG_02.png',
-    'focusModeBG_03.png',
-    'focusModeBG_04.png',
-    'focusModeBG_05.png',
-    'focusModeBG_06.png',
-    'focusModeBG_07.png',
-    'focusModeBG_08.png',
-] as const;
+let focusModeBackgroundsPromise: Promise<string[]> | null = null;
 
-export const focusModeBackgrounds = backgroundFileNames.map((fileName) =>
-    getSupabaseImageUrl(`focus-mode/backgrounds/${fileName}`)
-);
+const loadFocusModeBackgrounds = async () => {
+    if (!focusModeBackgroundsPromise) {
+        focusModeBackgroundsPromise = listSupabaseImageFiles('focus-mode/backgrounds').then((files) =>
+            files.map(({ name }) => getSupabaseImageUrl(`focus-mode/backgrounds/${name}`))
+        );
+    }
+
+    return focusModeBackgroundsPromise;
+};
 
 const getSlideClassName = (index: number, currentIndex: number, transition: BackgroundTransitionState | null) => {
     if (!transition) {
@@ -63,6 +60,7 @@ interface UseFocusModeBackgroundOptions {
 }
 
 export const useFocusModeBackground = ({ backgroundIndex }: UseFocusModeBackgroundOptions = {}) => {
+    const [focusModeBackgrounds, setFocusModeBackgrounds] = useState<string[]>([]);
     const persistedBackgroundIndex = useFocusModeBackgroundStore((state) => state.backgroundIndex);
     const setPersistedBackgroundIndex = useFocusModeBackgroundStore((state) => state.setBackgroundIndex);
     const [currentBackgroundIndex, setCurrentBackgroundIndex] = useState(() => {
@@ -75,6 +73,28 @@ export const useFocusModeBackground = ({ backgroundIndex }: UseFocusModeBackgrou
     const [backgroundTransition, setBackgroundTransition] = useState<BackgroundTransitionState | null>(null);
 
     useEffect(() => {
+        let cancelled = false;
+
+        const loadBackgrounds = async () => {
+            try {
+                const backgrounds = await loadFocusModeBackgrounds();
+
+                if (!cancelled) {
+                    setFocusModeBackgrounds(backgrounds);
+                }
+            } catch (error) {
+                console.error('집중모드 배경 목록을 불러오지 못했습니다.', error);
+            }
+        };
+
+        void loadBackgrounds();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    useEffect(() => {
         if (focusModeBackgrounds.length === 0) {
             setCurrentBackgroundIndex(0);
             return;
@@ -83,14 +103,14 @@ export const useFocusModeBackground = ({ backgroundIndex }: UseFocusModeBackgrou
         setCurrentBackgroundIndex(
             Math.min(backgroundIndex ?? persistedBackgroundIndex, focusModeBackgrounds.length - 1)
         );
-    }, [backgroundIndex, persistedBackgroundIndex]);
+    }, [backgroundIndex, focusModeBackgrounds.length, persistedBackgroundIndex]);
 
     useEffect(() => {
         focusModeBackgrounds.forEach((src) => {
             const image = new Image();
             image.src = src;
         });
-    }, []);
+    }, [focusModeBackgrounds]);
 
     useEffect(() => {
         if (backgroundTransition?.phase !== 'prepare') {
@@ -140,14 +160,14 @@ export const useFocusModeBackground = ({ backgroundIndex }: UseFocusModeBackgrou
             setCurrentBackgroundIndex(nextIndex);
             setPersistedBackgroundIndex(nextIndex);
         },
-        [backgroundTransition, currentBackgroundIndex, setPersistedBackgroundIndex]
+        [backgroundTransition, currentBackgroundIndex, focusModeBackgrounds.length, setPersistedBackgroundIndex]
     );
 
     const backgroundSlideClassNames = useMemo(() => {
         return focusModeBackgrounds.map((_, index) =>
             getSlideClassName(index, currentBackgroundIndex, backgroundTransition)
         );
-    }, [backgroundTransition, currentBackgroundIndex]);
+    }, [backgroundTransition, currentBackgroundIndex, focusModeBackgrounds]);
 
     return {
         focusModeBackgrounds,

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -3,9 +3,46 @@ import { supabase } from './supabase';
 const imageBucket = import.meta.env.VITE_SUPABASE_IMAGE_BUCKET ?? 'media-images';
 const audioBucket = import.meta.env.VITE_SUPABASE_AUDIO_BUCKET ?? 'media-audio';
 
+const fileEntryNamePattern = /\.[^./]+$/;
+
 const getPublicUrl = (bucket: string, path: string) => {
     return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl;
 };
 
+const listFiles = async (bucket: string, path: string, allowedExtensions: string[]) => {
+    const { data, error } = await supabase.storage.from(bucket).list(path, {
+        limit: 100,
+        sortBy: { column: 'name', order: 'asc' },
+    });
+
+    if (error) {
+        throw error;
+    }
+
+    return (data ?? []).filter((entry) => {
+        const extension = entry.name.split('.').pop()?.toLowerCase();
+
+        return Boolean(extension && allowedExtensions.includes(extension));
+    });
+};
+
+const listFolders = async (bucket: string, path: string) => {
+    const { data, error } = await supabase.storage.from(bucket).list(path, {
+        limit: 100,
+        sortBy: { column: 'name', order: 'asc' },
+    });
+
+    if (error) {
+        throw error;
+    }
+
+    return (data ?? []).filter((entry) => !fileEntryNamePattern.test(entry.name));
+};
+
 export const getSupabaseImageUrl = (path: string) => getPublicUrl(imageBucket, path);
 export const getSupabaseAudioUrl = (path: string) => getPublicUrl(audioBucket, path);
+export const listSupabaseImageFiles = (path: string) =>
+    listFiles(imageBucket, path, ['png', 'jpg', 'jpeg', 'webp', 'gif']);
+export const listSupabaseAudioFiles = (path: string) =>
+    listFiles(audioBucket, path, ['mp3', 'wav', 'ogg', 'm4a', 'aac']);
+export const listSupabaseAudioFolders = (path: string) => listFolders(audioBucket, path);

--- a/src/pages/My.tsx
+++ b/src/pages/My.tsx
@@ -1,18 +1,26 @@
+import { queryClient } from '@/api/queryClient';
+import { getGetMyProfileQueryKey } from '@/api/generated/users/users';
+import { deleteUserAvatar, mapUserResponseToAuthUser, uploadUserAvatar, useAuthStore } from '@/features/auth';
 import { Input, Toggle } from '@/components/form';
 import { CenteredLayout, Container, SectionHeader } from '@/components/layout';
 import { Button, Icon } from '@/components/ui';
 import { useModal, useToast } from '@/hooks';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 export default function My() {
     const panelClassName =
         'flex h-full min-h-0 w-full flex-col items-center rounded-2xl bg-white px-6 py-5 shadow-shadow-1';
+    const profileImageClassName = 'block size-full rounded-full object-cover bg-primary';
 
+    const user = useAuthStore((state) => state.user);
+    const updateUser = useAuthStore((state) => state.updateUser);
     const [name, setName] = useState('');
     const [focusTime, setFocusTime] = useState(0);
     const [shortBreakTime, setShortBreakTime] = useState(0);
     const [longBreakTime, setLongBreakTime] = useState(0);
     const [todoToggle, setTodoToggle] = useState(true);
+    const [isAvatarUploading, setIsAvatarUploading] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
 
     const { showToast } = useToast();
     const { showModal } = useModal();
@@ -42,21 +50,21 @@ export default function My() {
         longBreakTime: 30,
     };
 
+    const profileNickname = user?.nickname ?? dummyUser.nickname;
+    const profileAvatarSrc = user?.avatarSrc ?? null;
+    const hasAvatar = Boolean(profileAvatarSrc);
+
     useEffect(() => {
-        setName(dummyUser.nickname);
+        setName(profileNickname);
         setFocusTime(dummySettings.focus_min | initialTime.focusTime);
         setShortBreakTime(dummySettings.short_break_min | initialTime.shortBreakTime);
         setLongBreakTime(dummySettings.long_break_min | initialTime.longBreakTime);
         setTodoToggle(dummySettings.auto_carry_todo);
-    }, []);
+    }, [profileNickname]);
 
-    const isActiveNameSaveBtn = (): boolean => {
-        if (name.length >= 2 && name.length <= 20 && name !== dummyUser.nickname) {
-            return false;
-        }
-
-        return true;
-    };
+    const isNameSaveDisabled = useMemo(() => {
+        return !(name.length >= 2 && name.length <= 20 && name !== profileNickname);
+    }, [name, profileNickname]);
 
     const handleNameSave = () => {
         // TODO: 닉네임 저장 로직
@@ -115,6 +123,99 @@ export default function My() {
         });
     };
 
+    const handleAvatarPickerOpen = () => {
+        if (!user?.id || isAvatarUploading) {
+            return;
+        }
+
+        fileInputRef.current?.click();
+    };
+
+    const handleAvatarChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const selectedFile = event.target.files?.[0];
+
+        if (!selectedFile || !user?.id) {
+            return;
+        }
+
+        if (!selectedFile.type.startsWith('image/')) {
+            showToast({
+                message: '이미지 파일만 업로드할 수 있어요',
+                iconName: 'error',
+                duration: 3000,
+            });
+            event.target.value = '';
+            return;
+        }
+
+        if (selectedFile.size > 5 * 1024 * 1024) {
+            showToast({
+                message: '프로필 이미지는 5MB 이하만 업로드할 수 있어요',
+                iconName: 'error',
+                duration: 3000,
+            });
+            event.target.value = '';
+            return;
+        }
+
+        setIsAvatarUploading(true);
+
+        try {
+            const nextUser = await uploadUserAvatar(selectedFile);
+            updateUser(mapUserResponseToAuthUser(nextUser));
+            void queryClient.invalidateQueries({ queryKey: getGetMyProfileQueryKey() });
+            showToast({
+                message: '프로필 이미지를 변경했어요',
+                iconName: 'check',
+                duration: 3000,
+            });
+        } catch (error) {
+            console.error('프로필 이미지 업로드에 실패했습니다.', error);
+            showToast({
+                message: '프로필 이미지 업로드에 실패했어요',
+                iconName: 'error',
+                duration: 3000,
+            });
+        } finally {
+            setIsAvatarUploading(false);
+            event.target.value = '';
+        }
+    };
+
+    const handleAvatarDelete = async () => {
+        if (!user?.id || !hasAvatar) {
+            return;
+        }
+
+        try {
+            const nextUser = await deleteUserAvatar();
+            updateUser(mapUserResponseToAuthUser(nextUser));
+            void queryClient.invalidateQueries({ queryKey: getGetMyProfileQueryKey() });
+            showToast({
+                message: '프로필 이미지를 삭제했어요',
+                iconName: 'check',
+                duration: 3000,
+            });
+        } catch (error) {
+            console.error('프로필 이미지 삭제에 실패했습니다.', error);
+            showToast({
+                message: '프로필 이미지 삭제에 실패했어요',
+                iconName: 'error',
+                duration: 3000,
+            });
+        }
+    };
+
+    const handleAvatarDeleteConfirm = () => {
+        showModal({
+            title: '프로필 이미지 삭제',
+            description: '현재 프로필 이미지를 삭제하고 기본 아이콘으로 되돌릴까요?',
+            confirmLabel: '삭제하기',
+            tone: 'danger',
+            onConfirm: handleAvatarDelete,
+        });
+    };
+
     return (
         <Container>
             <CenteredLayout>
@@ -123,14 +224,49 @@ export default function My() {
                         <SectionHeader title='계정 관리' type='sub' />
                         <div className='my-4'>
                             <p className='ml-1 mb-1'>프로필</p>
-                            <div className='w-[100px] h-[100px] relative'>
-                                {/* {avatarSrc ? (
-                            <img alt='사용자 아바타' className={profileImageClassName} src={avatarSrc} />
-                            ) : ( */}
-                                <Icon name='avatar' size={100} />
-                                {/* )} */}
-                                <div className='w-[35px] h-[35px] flex justify-center items-center absolute right-0 bottom-0 border-1 border-(--color-tomato-50) rounded-full bg-primary'>
-                                    <Icon name='edit' color='color-white' size={20} />
+                            <div className='flex items-end gap-4'>
+                                <div className='w-[100px] h-[100px] relative shrink-0'>
+                                    {profileAvatarSrc ? (
+                                        <img
+                                            alt='사용자 아바타'
+                                            className={profileImageClassName}
+                                            src={profileAvatarSrc}
+                                        />
+                                    ) : (
+                                        <Icon name='avatar' size={100} />
+                                    )}
+                                    <button
+                                        aria-label='프로필 이미지 변경'
+                                        className='w-[35px] h-[35px] flex justify-center items-center absolute right-0 bottom-0 border-1 border-(--color-tomato-50) rounded-full bg-primary hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-60'
+                                        disabled={!user?.id || isAvatarUploading}
+                                        onClick={handleAvatarPickerOpen}
+                                        type='button'
+                                    >
+                                        <Icon name='edit' color='color-white' size={20} />
+                                    </button>
+                                    <input
+                                        accept='image/*'
+                                        className='hidden'
+                                        onChange={handleAvatarChange}
+                                        ref={fileInputRef}
+                                        type='file'
+                                    />
+                                </div>
+                                <div className='flex flex-col gap-2'>
+                                    <Button
+                                        disabled={!user?.id || isAvatarUploading}
+                                        onClick={handleAvatarPickerOpen}
+                                        variant='outline'
+                                    >
+                                        {isAvatarUploading ? '업로드 중...' : '이미지 업로드'}
+                                    </Button>
+                                    <Button
+                                        disabled={!hasAvatar || isAvatarUploading}
+                                        onClick={handleAvatarDeleteConfirm}
+                                        variant='ghost'
+                                    >
+                                        이미지 삭제
+                                    </Button>
                                 </div>
                             </div>
                         </div>
@@ -139,7 +275,7 @@ export default function My() {
                             <p className='ml-1 mb-1'>닉네임</p>
                             <div className='flex'>
                                 <Input className='mr-2' value={name} onChange={(e) => setName(e.target.value)} />
-                                <Button onClick={handleNameSave} disabled={isActiveNameSaveBtn()}>
+                                <Button onClick={handleNameSave} disabled={isNameSaveDisabled}>
                                     저장
                                 </Button>
                             </div>

--- a/src/routes/AuthLayout.tsx
+++ b/src/routes/AuthLayout.tsx
@@ -1,7 +1,7 @@
 import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 
 import { AuthHeader } from '@/components/layout/Header';
-import { useAuthStore } from '@/features/auth';
+import { mapUserResponseToAuthUser, useAuthStore } from '@/features/auth';
 import { useGlobalKeyboardShortcuts, useModal } from '@/hooks';
 import {
     FocusMode,
@@ -11,7 +11,7 @@ import {
     useTimerSessionController,
     useTimerStore,
 } from '@/features/timer';
-import { useGetMySettings } from '@/api/generated/users/users';
+import { useGetMyProfile, useGetMySettings } from '@/api/generated/users/users';
 import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { formatTimeParts } from '@/utils/timeUtils';
 
@@ -30,9 +30,16 @@ export function AuthLayout() {
     const navigate = useNavigate();
     const { showModal } = useModal();
 
-    const settingsQuery = useGetMySettings();
     const isAuth = useAuthStore((state) => state.isAuth);
     const logout = useAuthStore((state) => state.logout);
+    const user = useAuthStore((state) => state.user);
+    const updateUser = useAuthStore((state) => state.updateUser);
+    const settingsQuery = useGetMySettings();
+    const profileQuery = useGetMyProfile({
+        query: {
+            enabled: isAuth,
+        },
+    });
     const shouldShowTimerProgressBar = location.pathname !== '/main' && !isFocusMode;
     const { handleToggleTimer, handleRequestStopTimer } = useTimerSessionController();
 
@@ -76,6 +83,14 @@ export function AuthLayout() {
         );
     }, [settingsQuery.data, setDurations]);
 
+    useEffect(() => {
+        if (!profileQuery.data) {
+            return;
+        }
+
+        updateUser(mapUserResponseToAuthUser(profileQuery.data));
+    }, [profileQuery.data, updateUser]);
+
     const handleMusicClick = useCallback(() => {
         setShouldLoadBgmPlayer(true);
         setPlayerModalOpen(true);
@@ -99,6 +114,7 @@ export function AuthLayout() {
     return (
         <>
             <AuthHeader
+                avatarSrc={user?.avatarSrc ?? undefined}
                 onFocusModeClick={() => setIsFocusMode(true)}
                 onLogoutClick={handleLogoutClick}
                 onMusicClick={handleMusicClick}


### PR DESCRIPTION
## 변경 내용

- BGM과 집중모드 배경 이미지를 Supabase Storage에서 동적으로 조회하도록 변경
- 프로필 이미지 업로드/삭제 UI를 마이페이지에 추가
- 프로필 이미지 업로드/삭제 API 연동 추가
- 프로필 이미지 변경 후 헤더/마이페이지에 즉시 반영되도록 사용자 상태 갱신 로직 보완

## 관련 이슈

- Closes #

## 참고 사항

- BGM은 `media-audio/bgm/*`, 집중모드 배경은 `media-images/focus-mode/backgrounds/*` 경로를 기준으로 동적으로 조회합니다.
- 프로필 이미지는 사용자별 경로 기준으로 관리되며, 응답으로 내려온 `avatar_url`을 사용해 렌더링합니다.
- 초기에 프론트엔드에서 Supabase Storage에 직접 프로필 이미지를 업로드/삭제하는 방식으로 코드를 구현했지만, 현재 인증 구조에서는 Supabase `auth.uid()`와 서비스 사용자 ID를 직접 매칭하기 어려워 백엔드 API를 통해 처리하는 방식으로 구현했습니다.

## 확인 사항

- [+] 로컬에서 정상 동작을 확인했습니다.
- [+] 관련 없는 변경은 포함하지 않았습니다.
- [+] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [+] 변경 사항에 대한 테스트를 했습니다.
