### PR TITLE
fix: 로그 페이지 진입시, 당일 데이터 출력안해주는 오류

### DIFF
--- a/src/pages/DailyLog.tsx
+++ b/src/pages/DailyLog.tsx
@@ -25,6 +25,7 @@ const LOG_AUTO_SAVE_DURATION = 5000;
 export default function DailyLog() {
     const today = new Date();
     const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const todayDateKey = formatDate(todayStart, DATE_FORMAT.api);
 
     const [search, setSearch] = useState('');
     const [searchKeyword, setSearchKeyword] = useState('');
@@ -85,6 +86,7 @@ export default function DailyLog() {
     const mdEditorRef = useRef<MdEditorHandle | null>(null);
     const contentRef = useRef(content);
     const lastSavedContentRef = useRef(content);
+    const initialTodayLogSelectedRef = useRef(false);
     const deleteTimerMapRef = useRef<Record<string, number>>({});
 
     useEffect(() => {
@@ -476,6 +478,31 @@ export default function DailyLog() {
         setSelectedDate(date);
         setIsOpenCalendar(false);
     };
+
+    useEffect(() => {
+        if (
+            initialTodayLogSelectedRef.current ||
+            isLoading ||
+            isSearchMode ||
+            selectedLog ||
+            isContentDirty ||
+            formatDate(selectedDate, DATE_FORMAT.api) !== todayDateKey
+        ) {
+            return;
+        }
+
+        const todayLog = visibleLogs.find((log) => log.log_date === todayDateKey);
+
+        if (!todayLog) {
+            return;
+        }
+
+        initialTodayLogSelectedRef.current = true;
+        setSelectedLog(todayLog);
+        setTitle(todayLog.title ?? '');
+        resetContentState(todayLog.content ?? '');
+        setAutoSaveText(formatLastSaved(todayLog.updated_at ?? ''));
+    }, [isContentDirty, isLoading, isSearchMode, selectedDate, selectedLog, todayDateKey, visibleLogs]);
 
     const moveSelectedDate = (days: number) => {
         const nextDate = new Date(selectedDate);


### PR DESCRIPTION
## 변경 내용

- 로그 페이지 진입시 당일 날짜 데이터를 content 에 넣어주도록 수정했습니다.

## 관련 이슈

- Closes #

## 참고 사항

-

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 없는 변경은 포함하지 않았습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
