### PR TITLE
feat: 회고 캘린더에서 보기

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState, type KeyboardEvent } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useGetDailyLog } from '@/api/generated/daily-logs/daily-logs';
 import { useGetRetroLog } from '@/api/generated/retro-logs/retro-logs';
@@ -10,7 +11,7 @@ import {
 } from '@/api/generated/stats/stats';
 import { useGetMyProfile } from '@/api/generated/users/users';
 import type { DailyFocusStat, RetroLogTemplateType } from '@/api/generated/model';
-import { DATE_FORMAT, formatDate, getTodayDate, parseDate } from '@/utils';
+import { DATE_FORMAT, formatDate, getTodayDate, isValidApiDate, parseDate } from '@/utils';
 import { Container, SectionHeader, DoubleColumnLayout } from '@@/layout';
 import { SegmentedControl } from '@@/form';
 import { Icon, Tag } from '@@/ui';
@@ -34,6 +35,7 @@ const detailCardClassName = 'rounded-xl border border-neutral-lighter px-5 py-4'
 const detailCardHeaderClassName = 'mb-3 flex items-start justify-between gap-3';
 const detailLogTitleClassName = 'mb-2 text-sm font-semibold text-neutral-darker';
 const detailLogDescriptionClassName = 'text-xs text-neutral-darker line-clamp-3';
+const detailActionCardClassName = `${detailCardClassName} text-left transition-colors hover:cursor-pointer hover:border-primary-subtle hover:bg-neutral-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30`;
 const retroTagListClassName = 'flex flex-wrap gap-1.5';
 const retroTagMap = [
     { label: '기술', iconName: 'tech', className: '!border-danger !text-danger' },
@@ -41,6 +43,8 @@ const retroTagMap = [
     { label: '소통', iconName: 'communication', className: '!border-info !text-info' },
     { label: '감정', iconName: 'emotion', className: 'border-success-darker text-success-darker' },
 ] as const;
+type DashboardView = 'calendar' | 'history';
+
 const retroTemplateLabelMap: Record<RetroLogTemplateType, (typeof retroTagMap)[number]> = {
     Tech: retroTagMap[0],
     Decision: retroTagMap[1],
@@ -82,13 +86,30 @@ const hasFocusDate = (value: DailyFocusStat): value is DailyFocusStat & { focus_
     return typeof value.focus_date === 'string' && value.focus_date.length > 0;
 };
 
+const isDashboardView = (value: string | null): value is DashboardView => value === 'calendar' || value === 'history';
+
+const getDashboardViewFromParams = (searchParams: URLSearchParams): DashboardView => {
+    const view = searchParams.get('view');
+
+    return isDashboardView(view) ? view : 'calendar';
+};
+
+const getDashboardDateFromParams = (searchParams: URLSearchParams) => {
+    const date = searchParams.get('date');
+
+    return isValidApiDate(date) ? date : getTodayDate();
+};
+
 const isRetroTag = (tag: (typeof retroTagMap)[number] | null): tag is (typeof retroTagMap)[number] => {
     return Boolean(tag);
 };
 
 export default function Dashboard() {
-    const [view, setView] = useState<'calendar' | 'history'>('calendar');
-    const [selectedDate, setSelectedDate] = useState(getTodayDate());
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const searchParamString = searchParams.toString();
+    const [view, setView] = useState<DashboardView>(() => getDashboardViewFromParams(searchParams));
+    const [selectedDate, setSelectedDate] = useState(() => getDashboardDateFromParams(searchParams));
     const selectedDateObject = parseDate(selectedDate);
     const { data: profile } = useGetMyProfile();
     const { data: statsOverview } = useGetStatsOverview();
@@ -129,6 +150,26 @@ export default function Dashboard() {
         { label: '데일리로그', value: `${statsOverview?.total_daily_logs ?? 0}건` },
         { label: '회고', value: `${statsOverview?.total_retro_logs ?? 0}건` },
     ];
+
+    useEffect(() => {
+        const nextSearchParams = new URLSearchParams(searchParamString);
+
+        setView(getDashboardViewFromParams(nextSearchParams));
+        setSelectedDate(getDashboardDateFromParams(nextSearchParams));
+    }, [searchParamString]);
+
+    const navigateToLogPage = (path: '/dailylog' | '/retro') => {
+        navigate(`${path}?date=${selectedDate}`);
+    };
+
+    const handleDetailCardKeyDown = (event: KeyboardEvent<HTMLElement>, action: () => void) => {
+        if (event.key !== 'Enter' && event.key !== ' ') {
+            return;
+        }
+
+        event.preventDefault();
+        action();
+    };
 
     return (
         <main>
@@ -217,7 +258,15 @@ export default function Dashboard() {
                             <div className={detailPanelClassName}>
                                 <h2 className='font-semibold'>{formatDate(selectedDate, DATE_FORMAT.display)}</h2>
 
-                                <article className={detailCardClassName}>
+                                <article
+                                    className={detailActionCardClassName}
+                                    role='button'
+                                    tabIndex={0}
+                                    onClick={() => navigateToLogPage('/dailylog')}
+                                    onKeyDown={(event) =>
+                                        handleDetailCardKeyDown(event, () => navigateToLogPage('/dailylog'))
+                                    }
+                                >
                                     <div className={detailCardHeaderClassName}>
                                         <h3 className='font-bold'>데일리로그</h3>
                                         <Icon name='arrow_right' size={16} />
@@ -237,7 +286,15 @@ export default function Dashboard() {
                                     )}
                                 </article>
 
-                                <article className={detailCardClassName}>
+                                <article
+                                    className={detailActionCardClassName}
+                                    role='button'
+                                    tabIndex={0}
+                                    onClick={() => navigateToLogPage('/retro')}
+                                    onKeyDown={(event) =>
+                                        handleDetailCardKeyDown(event, () => navigateToLogPage('/retro'))
+                                    }
+                                >
                                     <div className={detailCardHeaderClassName}>
                                         <h3 className='font-bold'>회고</h3>
                                         <Icon name='arrow_right' size={16} />

--- a/src/pages/Retro.tsx
+++ b/src/pages/Retro.tsx
@@ -17,13 +17,14 @@ import { queryClient } from '@/api/queryClient';
 import RetroItem from '@/features/log/components/RetroItem';
 import { RETRO_CATEGORY_NAME, RETRO_FORM } from '@/features/log/retroConstants';
 import { useToast } from '@/hooks';
-import { DATE_FORMAT, formatDate } from '@/utils';
+import { DATE_FORMAT, formatDate, getTodayDate, isValidApiDate, parseDate } from '@/utils';
 import { isSameDate } from '@/utils/dateUtils';
 import { SearchInput, SegmentedControl } from '@@/form';
 import { Container, SectionHeader, SidebarContentLayout } from '@@/layout';
 import { Badge, Button, Calendar, Icon, RetroCard } from '@@/ui';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const RETRO_LOG_PAGE_SIZE = 10;
 
@@ -92,7 +93,17 @@ const isSameRetroContent = (left: RetroContent = {}, right: RetroContent = {}) =
     return Array.from(keys).every((key) => (left[key] ?? '') === (right[key] ?? ''));
 };
 
+const getInitialSelectedDate = (searchParams: URLSearchParams) => {
+    const routeDate = searchParams.get('date');
+
+    return parseDate(isValidApiDate(routeDate) ? routeDate : getTodayDate());
+};
+
 export default function Retro() {
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const routeDate = searchParams.get('date');
+    const routeDateKey = isValidApiDate(routeDate) ? routeDate : null;
     const today = new Date();
     const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
     const todayDateKey = formatDate(todayStart, DATE_FORMAT.api);
@@ -100,7 +111,7 @@ export default function Retro() {
 
     const [search, setSearch] = useState('');
     const [searchKeyword, setSearchKeyword] = useState('');
-    const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+    const [selectedDate, setSelectedDate] = useState<Date>(() => getInitialSelectedDate(searchParams));
     const [isOpenCalendar, setIsOpenCalendar] = useState(false);
     const [content, setContent] = useState<RetroContentMap>({});
     const [selectedCategory, setSelectedCategory] = useState(RETRO_CATEGORY_NAME.TECH);
@@ -162,6 +173,7 @@ export default function Retro() {
     const contentChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const contentRef = useRef(content);
     const lastSavedContentRef = useRef<RetroContentMap>({});
+    const isSelectedCategoryDirtyRef = useRef(isSelectedCategoryDirty);
     const selectedCategoryRef = useRef(selectedCategory);
     const selectedRetroRef = useRef<RetroLogListItem | undefined>(selectedRetro);
     const initialTodayRetroSelectedRef = useRef(false);
@@ -174,6 +186,10 @@ export default function Retro() {
     useEffect(() => {
         contentRef.current = content;
     }, [content]);
+
+    useEffect(() => {
+        isSelectedCategoryDirtyRef.current = isSelectedCategoryDirty;
+    }, [isSelectedCategoryDirty]);
 
     useEffect(() => {
         selectedCategoryRef.current = selectedCategory;
@@ -240,8 +256,11 @@ export default function Retro() {
             .filter((retro): retro is RetroLogListItem => retro !== null);
     };
 
-    const retroLogs = retroLogsResponse?.pages.flatMap((page) => page.items ?? []) ?? [];
-    const visibleRetroArr = getVisibleRetroList(retroLogs);
+    const retroLogs = useMemo(
+        () => retroLogsResponse?.pages.flatMap((page) => page.items ?? []) ?? [],
+        [retroLogsResponse]
+    );
+    const visibleRetroArr = useMemo(() => getVisibleRetroList(retroLogs), [retroLogs, pendingDeleteRetroIds]);
     const visibleSearchResults = retroSearchResults.filter(
         (retro) => !retro.id || !pendingDeleteRetroIds.includes(retro.id)
     );
@@ -359,11 +378,99 @@ export default function Retro() {
         };
     };
 
-    const initContent = () => {
-        console.log('INIT CONTENT');
+    const routeDateListRetro = useMemo(() => {
+        if (!routeDateKey) {
+            return undefined;
+        }
 
+        return visibleRetroArr.find((retro) => retro.retro_date && isSameDate(retro.retro_date, routeDateKey));
+    }, [routeDateKey, visibleRetroArr]);
+
+    const initContent = () => {
         resetContentState(createEmptyRetroContent());
     };
+
+    const clearRetroState = () => {
+        selectedRetroRef.current = undefined;
+        selectedCategoryRef.current = RETRO_CATEGORY_NAME.TECH;
+        setSelectedRetro(undefined);
+        setSelectedCategory(RETRO_CATEGORY_NAME.TECH);
+        initContent();
+        setAutoSaveState('');
+        setAutoSaveText('');
+    };
+
+    const applyRetroState = (retro: RetroLogListItem) => {
+        if (!retro.retros || !retro.template_types?.length) {
+            clearRetroState();
+            return;
+        }
+
+        const nextCategory = retro.template_types[0].toLowerCase();
+
+        selectedRetroRef.current = retro;
+        selectedCategoryRef.current = nextCategory;
+        setSelectedRetro(retro);
+        setSelectedCategory(nextCategory);
+        resetContentState(getRetroContentMap(retro.retros));
+        restoreCategorySaveState(nextCategory);
+    };
+
+    useEffect(() => {
+        if (!routeDateKey) {
+            return;
+        }
+
+        setSelectedDate(parseDate(routeDateKey));
+        setIsOpenCalendar(false);
+
+        if (routeDateListRetro && !isSelectedCategoryDirtyRef.current) {
+            applyRetroState(routeDateListRetro);
+        }
+    }, [routeDateKey, routeDateListRetro]);
+
+    useEffect(() => {
+        if (!routeDateKey) {
+            return;
+        }
+
+        let isCurrent = true;
+        const nextSelectedDate = parseDate(routeDateKey);
+
+        setSelectedDate(nextSelectedDate);
+        setIsOpenCalendar(false);
+
+        const syncRouteDate = async () => {
+            try {
+                const dateRetros = await getRetroLog({ date: routeDateKey });
+
+                if (!isCurrent || isSelectedCategoryDirtyRef.current) {
+                    return;
+                }
+
+                const matchedRetro = buildRetroListItem(dateRetros, routeDateKey);
+
+                if (!matchedRetro?.retros || !matchedRetro.template_types?.length) {
+                    clearRetroState();
+                    return;
+                }
+
+                applyRetroState(matchedRetro);
+            } catch {
+                if (!isCurrent || isSelectedCategoryDirtyRef.current) {
+                    return;
+                }
+
+                clearRetroState();
+            }
+        };
+
+        void syncRouteDate();
+
+        return () => {
+            isCurrent = false;
+        };
+    }, [routeDateKey]);
 
     const mergeRetroLogIntoSelectedRetro = (retroLog: RetroLog, baseRetro?: RetroLogListItem): RetroLogListItem => {
         const nextRetros = baseRetro?.retros?.some((item) => retroLog.id && item.id === retroLog.id)
@@ -573,6 +680,10 @@ export default function Retro() {
 
     const searchRetroList = () => {
         setSearchKeyword(search.trim());
+    };
+
+    const handleDashboardCalendarClick = () => {
+        navigate(`/dashboard?view=calendar&date=${formatDate(selectedDate, DATE_FORMAT.api)}`);
     };
 
     const handleSearchRetroClick = async (searchItem: RetroLogSearchItem) => {
@@ -1062,7 +1173,7 @@ ${selectedCategoryContent[key] ?? ''}
                                 <div ref={loadMoreRef} className='h-1 shrink-0' />
                             </div>
 
-                            <Button fullWidth={true} variant='outline'>
+                            <Button fullWidth={true} variant='outline' onClick={handleDashboardCalendarClick}>
                                 캘린더에서 보기
                             </Button>
                         </section>

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -54,6 +54,16 @@ export const parseDate = (value: string, options: formatDateOptions = DATE_FORMA
     }
 };
 
+export const isValidApiDate = (value: string | null | undefined): value is string => {
+    if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        return false;
+    }
+
+    const parsedDate = parseDate(value);
+
+    return !Number.isNaN(parsedDate.getTime()) && formatDate(parsedDate, DATE_FORMAT.api) === value;
+};
+
 export const isSameDate = (a: Date | string, b: Date | string) => {
     const aDate = typeof a === 'string' ? new Date(a) : a;
     const bDate = typeof b === 'string' ? new Date(b) : b;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,3 @@
-export { getTodayDate, formatDate, parseDate, DATE_FORMAT } from './dateUtils';
+export { getTodayDate, formatDate, parseDate, isValidApiDate, DATE_FORMAT } from './dateUtils';
 export { formatTimeParts, formatTimeLabel } from './timeUtils';
 export { cn } from './cn';


### PR DESCRIPTION
## 변경 내용

- 회고 캘린더에서 보기 기능 추가
- 대쉬보드에서 회고 누를시, 해당 날짜의 회고페이지로 이동

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 없는 변경은 포함하지 않았습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
