### PR TITLE
fix: 회고에 질문내용이 하나라도 빠진상태로 생성하면, 오류가 나는 문제

### DIFF
--- a/src/pages/Retro.tsx
+++ b/src/pages/Retro.tsx
@@ -95,6 +95,19 @@ const cloneRetroContentMap = (contentMap: RetroContentMap): RetroContentMap => {
     return Object.fromEntries(Object.entries(contentMap).map(([category, fields]) => [category, { ...fields }]));
 };
 
+const normalizeRetroContentByCategory = (category: string, categoryContent: RetroContent = {}): RetroContent => {
+    const categoryForm = RETRO_FORM[category.toUpperCase() as keyof typeof RETRO_FORM];
+
+    if (!categoryForm) {
+        return { ...categoryContent };
+    }
+
+    return Object.keys(categoryForm).reduce<RetroContent>((normalizedContent, key) => {
+        normalizedContent[key] = categoryContent[key] ?? '';
+        return normalizedContent;
+    }, {});
+};
+
 const isSameRetroContent = (left: RetroContent = {}, right: RetroContent = {}) => {
     const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
 
@@ -1037,7 +1050,7 @@ ${selectedCategoryContent[key] ?? ''}
             contentChangeTimerRef.current = null;
         }
 
-        const contentToSave = { ...(contentRef.current[categoryToSave] ?? {}) };
+        const contentToSave = normalizeRetroContentByCategory(categoryToSave, contentRef.current[categoryToSave]);
 
         if (!isCategoryContentDirty(categoryToSave)) {
             if (canUpdateUi() && selectedCategoryRef.current === categoryToSave) {


### PR DESCRIPTION
## 변경 내용

- 회고 생성시, 입력되지 않은 질문이 있는경우 400에러가 발생하는 현상을 수정했습니다.

## 확인 사항

- [x] 로컬에서 정상 동작을 확인했습니다.
- [x] 관련 없는 변경은 포함하지 않았습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
